### PR TITLE
Changes in lesson 4/2

### DIFF
--- a/lesson-4/2/02-sts.yaml
+++ b/lesson-4/2/02-sts.yaml
@@ -23,7 +23,7 @@ spec:
         - |
           set -ex
           # Generate mysql server-id from pod ordinal index.
-          [[ `hostname` =~ -([0-9]+)$ ]] || exit 1
+          [[ $HOSTNAME =~ -([0-9]+)$ ]] || exit 1
           ordinal=${BASH_REMATCH[1]}
           echo [mysqld] > /mnt/conf.d/server-id.cnf
           # Add an offset to avoid reserved server-id=0 value.

--- a/lesson-4/2/Readme.md
+++ b/lesson-4/2/Readme.md
@@ -12,12 +12,12 @@ kubectl create -f 02-ns.yaml
 Изучим файлики для запуска sts
 
 ```sh
-kubectl create -f 02-cm.yaml
+kubectl create -f 02-cm-svc.yaml
 ```
 
 Запустим сам sts и дождемся чтобы он создал все поды
 ```sh
-kubectl create -f 03-sts.yaml
+kubectl create -f 02-sts.yaml
 watch kubectl get pods -l app=mysql -n demo-ns # запустить во вкладке
 ```
 


### PR DESCRIPTION
Please review some changes in Readme.md and the following change in 02-sts.yaml:
- `hostname` for init-mysql container generates 'command not found' error during container execution. In the example here $HOSTNAME is used instead: https://kubernetes.io/docs/tasks/run-application/run-replicated-stateful-application/ 